### PR TITLE
update links and fix R CMD Check warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: ghBackup
-Title: An R package that backs up your GitHub repositories
+Title: An R Package that Backs Up your GitHub Repositories
 Version: 0.0.0.9000
 Authors@R:
     c(
@@ -17,12 +17,17 @@ Authors@R:
 Description: Provide functions to allow users to back up repositories in 
     organizations.
 Imports:
-    utils,
-    rjson
+    rjson,
+    utils
 License: GPL-3 + file LICENSE
 Suggests: 
+    gh,
+    knitr,
+    rmarkdown,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
+VignetteBuilder:
+    knitr

--- a/R/check_gh_size.r
+++ b/R/check_gh_size.r
@@ -15,7 +15,7 @@
 dir_size <- function(path) {
 
   # error message class
-  if (class(path) != "character") stop("class of the path is not character")
+  if (!inherits(path, "character")) stop("class of the path is not character")
   files <- list.files(path, full.names = T, recursive = T)
 
   if (length(files) == 0) {

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ ghBackup
 ghBackup is an R package that backs up your GitHub repositories. It uses 
 a GitHub personal access token to clone repositories from a GitHub 
 organization and save the files in the destination directory.
-[Simple examples](https://bai-li-noaa.github.io/ghBackup/articles/) on how to back up repositories and upload backup files 
+[Simple examples](https://nmfs-ost.github.io/ghBackup/articles/) on how to back up repositories and upload backup files 
 to a Google Drive folder on a schedule are provided. 
 
 # Installation
 
 ```r
-remotes::install_github("Bai-Li-NOAA/ghBackup")
+remotes::install_github("nmfs-ost/ghBackup")
 ```
 # Usage
  
@@ -34,7 +34,7 @@ ghBackup::back_up_gh_orgs(
 # Need Help?
 
 Get questions answered in 
-[issues](https://github.com/Bai-Li-NOAA/ghBackup/issues) or submit bug 
+[issues](https://github.com/nmfs-ost/ghBackup/issues) or submit bug 
 reports and feature requests to issues. 
 
 # Disclaimer

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,0 @@
-## R CMD check results
-
-0 errors | 0 warnings | 1 note
-
-* This is a new release.

--- a/inst/extdata/examples/example_back_up_gh.R
+++ b/inst/extdata/examples/example_back_up_gh.R
@@ -11,7 +11,7 @@ pkg_to_install <- required_pkg[!(required_pkg %in%
 if (length(pkg_to_install)) install.packages(pkg_to_install)
 lapply(required_pkg, library, character.only = TRUE)
 
-remotes::install_github("Bai-Li-NOAA/ghBackup")
+remotes::install_github("nmfs-ost/ghBackup")
 library(ghBackup)
 
 # Back up GitHub repositories -------------------------------------

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -19,12 +19,12 @@ navbar:
     github:
       text: Source Code
       icon: fab fa-github fa-lg
-      href: https://github.com/Bai-Li-NOAA/ghBackup/
+      href: https://github.com/nmfs-ost/ghBackup/
 
     issue:
       text: Issues
       icon: fas fa-question-circle fa-lg
-      href: https://github.com/Bai-Li-NOAA/ghBackup/issues/
+      href: https://github.com/nmfs-ost/ghBackup/issues/
 
     articles:
       text: Vignettes

--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -1,1 +1,1 @@
-@import url("https://nmfs-fish-tools.github.io/nmfspalette/extra.css");
+@import url("https://nmfs-ost.github.io/nmfspalette/extra.css");

--- a/vignettes/back-up-github-repositories.Rmd
+++ b/vignettes/back-up-github-repositories.Rmd
@@ -2,7 +2,11 @@
 title: "Back up GitHub repositories"
 author: "Bai Li"
 date: "9/26/2022"
-output: html_document
+output: github_document
+vignette: >
+  %\VignetteIndexEntry{Back up GitHub repositories}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
 ---
 
 ```{r setup, include=FALSE}
@@ -14,7 +18,7 @@ knitr::opts_chunk$set(echo = TRUE)
 This R package helps back up GitHub repositories from an organization using R. To install the package from GitHub:
 
 ```R
-remotes::install_github("Bai-Li-NOAA/ghBackup")
+remotes::install_github("nmfs-ost/ghBackup")
 ```
 
 You can read the help file with
@@ -67,7 +71,7 @@ googledrive::drive_put(
 )
 ```
 
-The full R script example can be found here: [inst/extdata/examples/example_back_up_gh.R](https://github.com/Bai-Li-NOAA/ghBackup/blob/main/inst/extdata/examples/example_back_up_gh.R).
+The full R script example can be found here: [inst/extdata/examples/example_back_up_gh.R](https://github.com/nmfs-ost/ghBackup/blob/main/inst/extdata/examples/example_back_up_gh.R).
 
 ## Schedule the run 
 
@@ -94,7 +98,7 @@ taskscheduleR::taskscheduler_create(
 )
 ```
 
-The full R script example can be found here: [inst/extdata/examples/example_task_schedule.R](https://github.com/Bai-Li-NOAA/ghBackup/blob/main/inst/extdata/examples/example_task_schedule.R).
+The full R script example can be found here: [inst/extdata/examples/example_task_schedule.R](https://github.com/nmfs-ost/ghBackup/blob/main/inst/extdata/examples/example_task_schedule.R).
 
 You might be interested in [cronR package](https://github.com/bnosac/cronR) if you would like to automate R workflow on Linux/Unix. 
 

--- a/vignettes/check-gh-size.Rmd
+++ b/vignettes/check-gh-size.Rmd
@@ -2,7 +2,11 @@
 title: "Check GH size"
 author: "Giselle Schmitz"
 date: "6/15/2022"
-output: html_document
+output: github_document
+vignette: >
+  %\VignetteIndexEntry{Check GH size}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
 ---
 
 ```{r setup, include=FALSE}
@@ -18,9 +22,9 @@ This package checks github repo size as a means of avoiding errors or oversized 
 Install package using the code below:
 
 ```{r setup_pkgs, eval= FALSE}
-#devtools::load_all()
+
 install.packages("remotes")
-remotes::install_github("Bai-Li-NOAA/ghBackup")
+remotes::install_github("nmfs-ost/ghBackup")
 library(ghBackup)
 ```
 


### PR DESCRIPTION
* Update the links and repo names in the package as some links on the pkgdown website don't work after transferring the repo to nmfs-ost
* update(DESCRIPTION): update Imports and Suggests sections to fix warnings from R CMD Check